### PR TITLE
Add Python-based Julian Date macro generator for TiddlyWiki

### DIFF
--- a/JulianDateMacro.py
+++ b/JulianDateMacro.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Generate a TiddlyWiki macro tiddler for Julian Date (JD) and Modified Julian Date (MJD)."""
+
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timezone
+
+
+def gregorian_to_jd(dt: datetime) -> float:
+    """Convert a UTC datetime to astronomical Julian Date."""
+    year = dt.year
+    month = dt.month
+    day = dt.day + (
+        dt.hour / 24
+        + dt.minute / 1440
+        + (dt.second + dt.microsecond / 1_000_000) / 86400
+    )
+
+    if month <= 2:
+        year -= 1
+        month += 12
+
+    a = year // 100
+    b = 2 - a + (a // 4)
+
+    jd = int(365.25 * (year + 4716)) + int(30.6001 * (month + 1)) + day + b - 1524.5
+    return jd
+
+
+def build_tiddler_text(now: datetime, title: str) -> str:
+    jd = gregorian_to_jd(now)
+    mjd = jd - 2400000.5
+    created = now.strftime("%Y%m%d%H%M%S000")
+
+    return f"""title: {title}
+type: text/vnd.tiddlywiki
+created: {created}
+modified: {created}
+
+\\define julianDate() {jd:.5f}
+\\end
+
+\\define modifiedJulianDate() {mjd:.5f}
+\\end
+
+''Julian Date:'' <<julianDate>>
+
+''Modified Julian Date:'' <<modifiedJulianDate>>
+"""
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--title",
+        default="$:/macros/JulianDate",
+        help="Tiddler title to generate (default: $:/macros/JulianDate)",
+    )
+    parser.add_argument(
+        "--iso-utc",
+        help="Optional UTC datetime in ISO format, e.g. 2026-04-25T12:00:00",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    now = (
+        datetime.fromisoformat(args.iso_utc).replace(tzinfo=timezone.utc)
+        if args.iso_utc
+        else datetime.now(timezone.utc)
+    )
+    print(build_tiddler_text(now, args.title))
+
+
+if __name__ == "__main__":
+    main()

--- a/tiddlers/JulianDateMacro.md
+++ b/tiddlers/JulianDateMacro.md
@@ -1,0 +1,20 @@
+# Julian Date macro for TiddlyWiki (Python-generated)
+
+Use the Python script below to generate a macro tiddler that stores the current
+Julian Date (`<<julianDate>>`) and Modified Julian Date (`<<modifiedJulianDate>>`).
+
+```bash
+python3 JulianDateMacro.py > tiddlers/$__macros_JulianDate.tid
+```
+
+Then reload TiddlyWiki and transclude it where needed:
+
+```tid
+{{||$:/macros/JulianDate}}
+```
+
+You can also generate for a specific UTC time:
+
+```bash
+python3 JulianDateMacro.py --iso-utc 2026-04-25T12:00:00
+```


### PR DESCRIPTION
### Motivation
- Provide a simple, repeatable way to generate Julian Date (JD) and Modified Julian Date (MJD) macros for inclusion in TiddlyWiki.
- Enable storing JD/MJD as TiddlyWiki macro tiddlers so pages can transclude fixed-generation timestamp values.
- Allow generation for the current UTC time or a specified ISO UTC time so macro values can be reproduced or regenerated on demand.

### Description
- Add `JulianDateMacro.py`, a small Python utility that computes astronomical JD and MJD from a UTC `datetime` and formats a TiddlyWiki tiddler payload containing `\define julianDate()` and `\define modifiedJulianDate()` macros.
- The script exposes `--iso-utc` to generate values for a specific UTC timestamp and `--title` to set the tiddler title (default: `$:/macros/JulianDate`).
- Output includes standard tiddler headers (`title`, `type`, `created`, `modified`) and macro definitions with numeric values formatted to five decimal places so the result can be written into `tiddlers/` and reloaded by TiddlyWiki.
- Add `tiddlers/JulianDateMacro.md` with usage examples showing how to run the script and transclude the generated macro in TiddlyWiki.

### Testing
- Ran `python3 JulianDateMacro.py --iso-utc 2026-04-25T12:00:00 | sed -n '1,40p'` and confirmed the printed output contains tiddler headers and the `\define julianDate()` and `\define modifiedJulianDate()` macro definitions with expected numeric values.
- The script invocation produced the expected `.tid` payload format and the test inspection succeeded without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecd2429c30832084fb04f120f4442f)

## Summary by Sourcery

Add a Python utility to generate TiddlyWiki macro tiddlers containing Julian Date (JD) and Modified Julian Date (MJD) values for a given UTC timestamp.

New Features:
- Provide a command-line script that converts UTC datetimes to astronomical Julian Date and Modified Julian Date and outputs a TiddlyWiki macro tiddler payload.
- Allow specifying the tiddler title and an explicit ISO-formatted UTC datetime when generating the macro values.

Documentation:
- Add a markdown tiddler documenting how to run the Julian Date macro generator script and transclude the resulting macros in TiddlyWiki.